### PR TITLE
Fix Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm star
+web: npm start


### PR DESCRIPTION
Skipping deployment (#skip) since Heroku should be running an earlier non-broken version.